### PR TITLE
Correct mongoid gem dependency (requires >= 3.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mongorestore = Mongoid::Shell::Commands::Mongorestore.new({ collection: 'test', 
 mongorestore.to_s # mongorestore --db test --collection test /tmp/db_backup
 ```
 
-The `Mongoid::Shell::Commands::Mongorestore` class supports `--db`, `--host`, `--username`, `--password`, `--collection`, `--ipv6, `--dbpath`, `--directoryperdb`, `--journal`, `--objcheck`, `--filter`, `--drop`, `--oplogReplay` and `--keepIndexVersion`.
+The `Mongoid::Shell::Commands::Mongorestore` class supports `--db`, `--host`, `--username`, `--password`, `--collection`, `--ipv6`, `--dbpath`, `--directoryperdb`, `--journal`, `--objcheck`, `--filter`, `--drop`, `--oplogReplay` and `--keepIndexVersion`.
 
 ### Mongostat
 

--- a/mongoid-shell.gemspec
+++ b/mongoid-shell.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/dblock/mongoid-shell"
   s.licenses = [ "MIT" ]
   s.summary = "Derive shell commands from Mongoid configuration options."
-  s.add_dependency "mongoid"
+  s.add_dependency "mongoid", ">= 3.0.0"
   s.add_dependency "i18n"
 end
 


### PR DESCRIPTION
Also adding a missing backtick to `README.md`.
